### PR TITLE
Page reload after drag and drop

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -19,8 +19,9 @@ class GamesController < ApplicationController
   end
 
   def update
-    #redirect_to game_path(current_game)
-    head :no_content
+    @game = Game.find(params[:id])
+    render "show"
+    #head :no_content
   end
 
   def join

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -36,7 +36,7 @@ class PiecesController < ApplicationController
 			@piece.game.turn_over
 		end
 			puts errors
-			redirect_to game_path(@piece.game)
+			render "reload"
 	end
 
 	def castle_queen

--- a/app/views/pieces/reload.js.erb
+++ b/app/views/pieces/reload.js.erb
@@ -1,0 +1,1 @@
+document.location.reload()

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Pawn, type: :model do
   describe "valid move" do
 
     it "should be able to make a step move" do
-      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 1, white?: true)
-      expect(pawn.valid_move?(3, 2)).to eq true
+      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 6, white?: true)
+      expect(pawn.valid_move?(3, 5)).to eq true
     end
     it "should be able to make a jump move" do
-      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 1, white?: true)
-      expect(pawn.valid_move?(3, 3)).to eq true
+      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 6, white?: true)
+      expect(pawn.valid_move?(3, 4)).to eq true
     end
     it "should not be able to make a jump move if has moved" do
       pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 2, moved: true, white?: true)
@@ -26,8 +26,8 @@ RSpec.describe Pawn, type: :model do
     end
     
     it "black piece should not be able to move backwards" do
-      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 2, white?: false)
-      expect(pawn.valid_move?(3, 3)).to eq false
+      pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 5, white?: false)
+      expect(pawn.valid_move?(3, 6)).to eq false
     end
     it "should not be able to move off the board" do
       pawn = Pawn.create(game_id: game.id, x_position: 3, y_position: 0, white?: true)


### PR DESCRIPTION
Updated piece and game controllers to reload the board after a chess piece is moved.  Invalid moves should return to previous coordinate and valid moves should update to new coordinate.  Also did some general debugging for some rspec pawn tests.